### PR TITLE
Add configuration to not delete the parent.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,6 @@ module.exports = (function () {
           // Parent for this object is not yet in temp, adding it to pendingChildOf.
           initPush(parent, pendingChildOf, flatEl);
         }
-        delete flatEl[this.config.parent];
       }
       if (pendingChildOf[id] !== undefined) {
         // Current object has children pending for it. Adding these to the object.

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = (function () {
     this.config.id = config.id || 'id';
     this.config.parent = config.parent || 'parent';
     this.config.children = config.children || 'children';
+    this.config.options = config.options || { deleteParent: true };
   }
 
   /**
@@ -41,6 +42,9 @@ module.exports = (function () {
         } else {
           // Parent for this object is not yet in temp, adding it to pendingChildOf.
           initPush(parent, pendingChildOf, flatEl);
+        }
+        if(this.config.options.deleteParent){
+          delete flatEl[this.config.parent];
         }
       }
       if (pendingChildOf[id] !== undefined) {

--- a/test/test.js
+++ b/test/test.js
@@ -218,4 +218,27 @@ describe('flatToNested', function () {
       assert.deepEqual(flatToNested.convert(flat), expected);
     });
   });
+
+  describe('using options to not delete the parent', function(){
+    var flatToNested;
+
+    flatToNested = new FlatToNested({
+      options:{
+        deleteParent:false
+      }
+    });
+
+    it('should have parent after convert', function () {
+      var flat, expected, actual;
+
+      flat = [{id: 1},{id: 2, parent: 1}];
+
+      expected = {id: 1, children: [
+        { id: 2 , parent: 1 }
+      ]};
+
+      actual = flatToNested.convert(flat);
+      assert.deepEqual(actual, expected);
+    });
+  })
 });


### PR DESCRIPTION
I'm building a tree using https://www.npmjs.com/package/tree-model  and saving child nodes of the tree on the firebase. `flatToNested.convert()` is deleting the parent which in turn also deleting the parent from firebase.
